### PR TITLE
Fix Backspace issue inside docker

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -102,10 +102,10 @@ nmap <C-g>b :Gblame<CR>
 "imap <C-Up> <Esc><C-W><Up>
 "imap <C-Down> <Esc><C-W><Down>
 
-imap <C-l> <Esc><C-W><Right>
-imap <C-h> <Esc><C-W><Left>
-imap <C-k> <Esc><C-W><Up>
-imap <C-j> <Esc><C-W><Down>
+"imap <C-l> <Esc><C-W><Right>
+"imap <C-h> <Esc><C-W><Left>
+"imap <C-k> <Esc><C-W><Up>
+"imap <C-j> <Esc><C-W><Down>
 
 "tmap <C-Right> <Esc><C-W><Right>
 "tmap <C-Left> <Esc><C-W><Left>


### PR DESCRIPTION
Inside my docker on windows (didn't;t check, maybe happens also on Ubuntu) this lines cause backspace not to work well - every press getting out of insert mode